### PR TITLE
simple elexis-3-core factory

### DIFF
--- a/elexis3factory/build_elexis.sh
+++ b/elexis3factory/build_elexis.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+######### Elexis Core
 cd /opt/elexisfactory
 if [ -d "/opt/elexisfactory/elexis-3-core" ]
 then
@@ -11,7 +12,21 @@ else
   git clone https://github.com/elexis/elexis-3-core
 fi
 cd /opt/elexisfactory/elexis-3-core
-git pull
 mvn clean install -Dmaven.test.skip=true -Pall-archs
 mkdir /opt/elexisfactory/dist
 cp -r /opt/elexisfactory/elexis-3-core/ch.elexis.core.p2site/target/products/* /opt/elexisfactory/dist
+
+######### Elexis Base
+cd /opt/elexisfactory
+if [ -d "/opt/elexisfactory/elexis-3-base" ]
+then
+  echo "pull elexis-3-base"
+  cd elexis-3-base
+  git pull
+  cd ..
+else
+  echo clone elexis-3-base
+  git clone https://github.com/elexis/elexis-3-base
+fi
+cd /opt/elexisfactory/elexis-3-base
+mvn clean install -Dmaven.test.skip=true

--- a/elexis3factory/readme.md
+++ b/elexis3factory/readme.md
@@ -32,11 +32,11 @@ To persist a container with preloaded repositories into a new docker image, try 
     
     
 where 'thirsty_brown' is the name of the container as found with `docker ps -a`.
-One can create a new container frum such an image with:
+One can create a new container from such an image with:
 
    sudo docker run -v /path/to/sources:/opt/elexisfactory rgwch/elexisfactory:1.1.0 
   
-Much the same way than with reusing a container, maven repositories are preloaded in this image, thus speeding up the compile process.
+Much the same way than with reusing a container, maven repositories are preloaded in this image, thus speeding up the compile process. The downside is, that such an image is much larger than the pristine elexisfactory.
 
 
 ### Using a different upstream repository

--- a/elexis3factory/readme.md
+++ b/elexis3factory/readme.md
@@ -1,6 +1,8 @@
 ### Simple factory for elexis-3-core and elexis-3-base
 
-Usage: 
+Usage:
+
+(The docker image is on dockerhub, so no need to build it yourself.)
 
     sudo docker run -v /path/to/elexis/sources:/opt/elexisfactory rgwch/elexisfactory
 

--- a/elexis3factory/readme.md
+++ b/elexis3factory/readme.md
@@ -1,4 +1,4 @@
-### Simple factory for elexis-3-core
+### Simple factory for elexis-3-core and elexis-3-base
 
 Usage: 
 
@@ -6,11 +6,16 @@ Usage:
 
 where `/path/to/elexis/sources` ist a directory on the host, where the elexis-3-core repository is or can be cloned into.
 
-_Note_: On Mac and Windows-Hosts, this directory must be within the User's home, or docker won't be able to access it.
+_Note_: On Mac and Windows-Hosts, this directory must be within the User's home, or docker won't be able to access it. (see [here](https://docs.docker.com/userguide/dockervolumes/) this note: 
+ 
+----     
+ "Note: If you are using Docker Machine on Mac or Windows, your Docker daemon only has limited access to your OS X/Windows filesystem. Docker Machine tries to auto-share your /Users (OS X) or C:\Users (Windows) directory - and so you can mount files or directories using docker run -v /Users/<path>:/<container path> ... (OS X) or docker run -v /c/Users/<path>:/<container path ... (Windows). All other paths come from your virtual machine’s filesystem."
 
-The factory will clone elexis-3-core, if the repository doesn't exist. If it exists, it will `git pull` to update. 
-Then it creates the elexis core for all supported architectures
-and copies them to `/path/to/elexis/sources/dist` after successful build.
+---                                                                                                                        
+                                                                                                                                
+
+The factory will clone elexis-3-core, and elexis-3-base, if the respective repository doesn't exist. If it exists, it will `git pull` to update. 
+Then it creates the elexis core for all supported architectures and copies them to `/path/to/elexis/sources/dist` after successful build. The files of elexis-3-base are compiled and left in-place.
 
 ### Speeding up consecutive builds
 
@@ -18,12 +23,23 @@ To re-use a container, find the container using `sudo docker ps -a` and relaunch
 
     sudo docker start -ia name_of_container
     
-This will re-use the downloaded maven repository and rebuild the elexis product
+This will re-use the downloaded maven repository and rebuild the elexis product, saving a lot of time compared to a build from scratch.
 
 
 To persist a container with preloaded repositories into a new docker image, try something like this:
 
-    docker commit -a "weirich@elexis.ch" -m "loaded maven repository" thirsty_brown rgwch/elexisfactory:1.1.0
+    sudo docker commit -a "weirich@elexis.ch" -m "loaded maven repository" thirsty_brown rgwch/elexisfactory:1.1.0
     
     
 where 'thirsty_brown' is the name of the container as found with `docker ps -a`.
+One can create a new container frum such an image with:
+
+   sudo docker run -v /path/to/sources:/opt/elexisfactory rgwch/elexisfactory:1.1.0 
+  
+Much the same way than with reusing a container, maven repositories are preloaded in this image, thus speeding up the compile process.
+
+
+### Using a different upstream repository
+
+Since elexisfactory applies only a `git pull`, if it finds an existing repository, this is easy: Check out the desired repository manually into the directory you give to elexisfactory.
+If no repository ist found there, elexisfactory will always check out http://github.com/elexis/elexis-3-core and http://github.com/elexis/elexis-3-base.

--- a/readme.textile
+++ b/readme.textile
@@ -5,6 +5,7 @@ Here you find a few dockerfiles which you might find interesting for playing aro
 Consult the readme.textile in each subdirectory you are intersted in. Their purpose are
 
 * build_elexis:  Complete environment, which lets you build and run the unit test for elexis-3-core and elexis-3-base
+* elexis3factory: Simple One-Step factory for elexis-3-core and elexis-3-base without testing.
 * elexis_test: Run the elexis-3-core + base with a demoDB, ch.elexis.base.ch.feature and some commonly used
 * jenkins: Run the Jenkins-CI with the same sets of plugins as under https://jenkins.elexis.info/jenkins/
 * mediawiki: Run a mediawiki enviroment (at the moment ahead of the actual wiki.elexis.info)

--- a/readme.textile
+++ b/readme.textile
@@ -20,7 +20,7 @@ Support for older docker version is no priority for me, but patches to support t
 
 I try to base my dockerfiles on Debian:jessie
 
-h3. Running under MacOSX
+h3. Running tests under MacOSX
 
 Searching around in the web I found via "Tim Sutton":http://kartoza.com/how-to-run-a-linux-gui-application-on-osx-using-docker/ and "Jan":http://learning-continuous-deployment.github.io/docker/images/dockerfile/2015/04/22/docker-gui-osx/ that you can run a tradition Linux X base application given:
 
@@ -32,6 +32,7 @@ Searching around in the web I found via "Tim Sutton":http://kartoza.com/how-to-r
 * You can only use directories starting /Users as docker data containers
 
 Tested with build_elexis on MacOSX 10.9 (at least 10.8 is required)
+_Note:_ These steps are not necessary for build-only without unit tests (as in elexis3factory)
 
 h3. Remove dangling docker files
 


### PR DESCRIPTION
I tried to simplify the build container and reduce it to one process: Build elexis-3-core.  No tests, no lexis-3-base this time. This works here on mac and ubuntu hosts.
